### PR TITLE
fix(feature-card): ensured feature-card large renders

### DIFF
--- a/src/pages/example-page-b/example-page-b.hbs
+++ b/src/pages/example-page-b/example-page-b.hbs
@@ -44,7 +44,7 @@
               </dds-leadspace-block-cta>
             </dds-leadspace-block-content>
           </dds-leadspace-block>
-          <dds-feature-card href='https://example.com'>
+          <dds-feature-card size='large' href='https://example.com'>
             <dds-image slot='image' alt='Image alt text' default-src='../assets/images/720/fpo--4x3--720x540--001.jpg'>
             </dds-image>
             <dds-card-eyebrow>scelerisque purus</dds-card-eyebrow>


### PR DESCRIPTION
### Related Ticket(s)
https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6680

### Description
The original issue has been fixed, but it seems that the Feature Card was not properly rendering. This PR adds the `size='large'` attribute that turns it into a Feature Card Large as it was originally intended.

The Feature Card component is in Example page B

### Changelog

**New**

- added `size='large'` to the Feature Card component in Example page B
